### PR TITLE
Fix: admin 페이지, 슈퍼유저 버그 픽스

### DIFF
--- a/bobpience_config/urls.py
+++ b/bobpience_config/urls.py
@@ -4,7 +4,7 @@ from drf_spectacular.views import (SpectacularAPIView, SpectacularRedocView,
                                    SpectacularSwaggerView)
 
 urlpatterns = [
-    path("api/admin/", admin.site.urls),
+    path("admin/", admin.site.urls),
     # Swagger-UI
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path(

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,11 +1,10 @@
 from django.contrib import admin
-from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.admin import UserAdmin
 
 from .models import CustomUser
 
 
-@admin.register(CustomUser)
-class CustomUserAdmin(BaseUserAdmin):
+class CustomUserAdmin(UserAdmin):
     fieldsets = (
         (
             None,
@@ -25,3 +24,6 @@ class CustomUserAdmin(BaseUserAdmin):
     list_display = ("email", "nickname")
     search_fields = ("email", "nickname")
     ordering = ("email",)
+
+
+admin.site.register(CustomUser, CustomUserAdmin)

--- a/users/models.py
+++ b/users/models.py
@@ -6,21 +6,22 @@ from common.models import CommonModel
 
 
 class CustomUserManager(BaseUserManager):
-    def create_user(self, email, password, **extra_fields):
+    def create_user(self, email, password, nickname, **extra_fields):
         if not email:
             raise ValueError("Email은 필수 입력 사항입니다.")
         if not password:
             raise ValueError("Password는 필수 입력 사항입니다.")
+        if not nickname:
+            raise ValueError("Nickname은 필수 입력 사항입니다.")
 
         # normalize_email 메서드는 사용자가 입력한 이메일 주소를 대소문자를 일치시켜 표준화된 형식으로 변환한다.
         email = self.normalize_email(email)
-        user = self.model(email=email, **extra_fields)
+        user = self.model(email=email, nickname=nickname**extra_fields)
         user.set_password(password)
         user.save(using=self._db)
         return user
 
     def create_superuser(self, email, password, nickname, **extra_fields):
-        # super user도 is_staff 기능이 있어야 admin 페이지에 접속 가능하다.
         extra_fields.setdefault("is_staff", True)
         extra_fields.setdefault("is_superuser", True)
 
@@ -43,10 +44,10 @@ class CustomUser(AbstractBaseUser, PermissionsMixin, CommonModel):
 
     objects = CustomUserManager()
 
-    # 이메일을 유저네임 필드로 사용
+    # 이메일을 username 필드로 사용
     USERNAME_FIELD = "email"
-    # 슈퍼유저를 생성할 때 반드시 입력받아야 하는 필드
-    REQUIRED_FIELDS = []
+    # 슈퍼유저를 생성할 때 반드시 입력 받아야 하는 필드
+    REQUIRED_FIELDS = ["nickname"]
 
     def __str__(self):
         return self.email


### PR DESCRIPTION
- admin 페이지에서 유저 데이터를 업데이트 하면 auth.User 테이블을 참조하는 에러 수정 처음 migrate된 내역이 남아 있어서 발생한 오류로 추정 db에서 해당하는 foregin키 직접 바꿔서 해결

- createsuperuser 함수 업데이트 Nickname을 반드시 입력 받게끔 포함시킴

  url 주소 수정
  - api/admin -> admin으로 수정